### PR TITLE
Fix ddl-auto property

### DIFF
--- a/src/main/java/np/com/roshanadhikary/blog/bootstrap/Bootstrap.java
+++ b/src/main/java/np/com/roshanadhikary/blog/bootstrap/Bootstrap.java
@@ -89,6 +89,7 @@ public class Bootstrap implements ApplicationListener<ContextRefreshedEvent> {
 
 				Optional<Post> postOptional = postRepository.findById(id);
 				if (postOptional.isEmpty()) {
+					System.out.println("Post with ID: " + id + " does not exist. Creating post...");
 					post.setTitle(title);
 					post.setAuthor(author);
 					post.setContent(lines);
@@ -96,6 +97,9 @@ public class Bootstrap implements ApplicationListener<ContextRefreshedEvent> {
 					post.setDateTime(LocalDateTime.now());
 
 					postRepository.save(post);
+					System.out.println("Post with ID: " + id + " created.");
+				} else {
+					System.out.println("Post with ID: " + id + " exists.");
 				}
 			} else {
 				System.out.println("postFileName is null, should not be null");

--- a/src/main/resources/application-heroku.properties
+++ b/src/main/resources/application-heroku.properties
@@ -1,4 +1,5 @@
 spring.datasource.url=${DATASOURCE_URL}
 spring.datasource.username=${DATASOURCE_USERNAME}
 spring.datasource.password=${DATASOURCE_PASSWORD}
+spring.jpa.hibernate.ddl-auto=none
 spring.mvc.favicon.enabled=true


### PR DESCRIPTION
Set the `ddl-auto` property to `none` for the *heroku* profile. This prevents dropping and creating schemas everytime the application boots.